### PR TITLE
LoadAudio and slider fixes

### DIFF
--- a/Components/FrequencyAdjuster/AdjusterPlayer.js
+++ b/Components/FrequencyAdjuster/AdjusterPlayer.js
@@ -1,8 +1,10 @@
 import * as React from "react";
-import { View, Image, TouchableOpacity } from "react-native";
+import { View, Image, TouchableOpacity, Text } from "react-native";
 import { Audio } from "expo-av";
 import styles from "../../Style/styles";
+import { COLORS } from "../../Style/colorScheme";
 import SeekBar from "./SeekBar";
+import Modal from "react-native-modal";
 
 export default function SoundPlayer(props) {
 
@@ -13,6 +15,17 @@ export default function SoundPlayer(props) {
   const [currentPos, setCurrentPos] = React.useState(0);
   const [intervalId, setIntervalId] = React.useState(0);
   const [currentURI, setURI] = React.useState("");
+
+  // Error message modal
+  const [isModalVisible, setModalVisible] = React.useState(false);
+
+  const openModal = () => {
+    setModalVisible(true);
+  };
+
+  const closeModal = () => {
+    setModalVisible(false);
+  };
 
   // get audio length from sound
   const setDuration = (sound) => {
@@ -64,7 +77,7 @@ export default function SoundPlayer(props) {
 
     if (shiftedURI === "NOT SET"){
       console.log("Attempting to load before audio is recorded!");
-      // TODO: could open modal here
+      openModal();
       return;
     }
     else if (shiftedURI === currentURI) {
@@ -157,20 +170,24 @@ export default function SoundPlayer(props) {
 
   const ReplayAudio = async () => {
     try {
-      LoadAudio();
-      clearInterval(intervalId);
-      sound.current.replayAsync();
-      setStatus(true);
-      setTime(sound, 0);
+      if (shiftedURI === currentURI) {
+        clearInterval(intervalId);
+        sound.current.replayAsync();
+        setStatus(true);
+        setTime(sound, 0);
 
-      const interval = setInterval(updatePos, 300);
-      setIntervalId(interval);
-      sound.current.setOnPlaybackStatusUpdate((status) => {
-        if (status.didJustFinish) {
-          setStatus(false);
-        }
-      });
-      console.log("Audio replaying");
+        const interval = setInterval(updatePos, 300);
+        setIntervalId(interval);
+        sound.current.setOnPlaybackStatusUpdate((status) => {
+          if (status.didJustFinish) {
+            setStatus(false);
+          }
+        });
+        console.log("Audio replaying");
+      }
+      else {
+        LoadAudio();
+      }
     } catch (error) {
       setStatus(false);
     }
@@ -178,6 +195,45 @@ export default function SoundPlayer(props) {
 
   return (
     <View>
+      <Modal
+        isVisible={isModalVisible}
+        style={styles.center}
+        backdropOpacity={0.8}
+      >
+        <View
+          style={[
+            styles.center,
+            {
+              width: 200,
+              height: 200,
+              backgroundColor: "white",
+              borderRadius: 30,
+              padding: 20,
+            },
+          ]}
+        >
+          <Text style={styles.body}>
+            You need to record or import an audio first!
+          </Text>
+
+          <View style={[styles.row, { justifyContent: "space-around" }]}>
+            <TouchableOpacity
+              style={[
+                styles.button,
+                {
+                  borderRadius: 30,
+                  backgroundColor: COLORS.RED,
+                  marginRight: 10,
+                  marginTop: 20,
+                },
+              ]}
+              onPress={() => closeModal()}
+            >
+              <Text style={styles.h3}>Close</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </Modal>
       <View style={styles.progressBar}>
         <SeekBar
           onSlidingStart={() => PauseAudio()}

--- a/Components/FrequencyAdjuster/AdjusterPlayer.js
+++ b/Components/FrequencyAdjuster/AdjusterPlayer.js
@@ -73,11 +73,10 @@ export default function SoundPlayer(props) {
         setURI(result.uri);
         setTime(sound, 0);
         setDuration(result);
-        // if (result.isLoaded === false) {
-        //   console.log("Error in Loadng Audio");
-        // } else {
-        //   await PlayAudio();
-        // }
+        sound.current.playFromPositionAsync(currentPos);
+        setStatus(true);
+        const interval = setInterval(updatePos, 300);
+        setIntervalId(interval);
       } catch (error) {
         console.log("Error in Loading Audio: " + error);
       }
@@ -90,12 +89,13 @@ export default function SoundPlayer(props) {
       // what to do if old is loaded?
       if (result.isLoaded && shiftedURI === currentURI) {
         if (result.isPlaying === false) {
-          if (currentPos === totalLength) {
-            sound.current.playFromPositionAsync(0);
-          }
-          else {
-            sound.current.playFromPositionAsync(currentPos);
-          }
+          // if (currentPos === totalLength) {
+          //   sound.current.playFromPositionAsync(0);
+          // }
+          // else {
+          //   sound.current.playFromPositionAsync(currentPos);
+          // }
+          sound.current.playFromPositionAsync(currentPos);
           setStatus(true);
           const interval = setInterval(updatePos, 300);
           setIntervalId(interval);

--- a/Components/FrequencyAdjuster/AdjusterPlayer.js
+++ b/Components/FrequencyAdjuster/AdjusterPlayer.js
@@ -61,7 +61,7 @@ export default function SoundPlayer(props) {
       }
       // onPlaybackStatusUpdate stopped the audio
       else if (!result.isPlaying) {
-        console.log(intervalId);
+        //console.log(intervalId);
         clearInterval(intervalId); // FIXME: gets old intervalId, doesn't clear
         setCurrentPos(result.durationMillis);
       }
@@ -99,7 +99,7 @@ export default function SoundPlayer(props) {
         setStatus(true);
         const interval = setInterval(updatePos, 300);
         setIntervalId(interval);
-        
+
         sound.current.setOnPlaybackStatusUpdate((status) => {
           if (status.didJustFinish) {
             setStatus(false);
@@ -110,7 +110,7 @@ export default function SoundPlayer(props) {
       }
     }
   };
-  
+
   const PlayAudio = async () => {
     try {
       const result = await sound.current.getStatusAsync();
@@ -246,7 +246,11 @@ export default function SoundPlayer(props) {
       <View style={[styles.row, { justifyContent: "space-around" }]}>
         <TouchableOpacity
           onPress={Status === false ? () => PlayAudio() : () => PauseAudio()}
-          style={styles.circleButton}
+          style = {
+            props.getShiftedURI() === "NOT SET"
+              ? [styles.circleButton, {backgroundColor: COLORS.GREY}]
+              : styles.circleButton
+            }
         >
           <Image
             source={
@@ -258,10 +262,24 @@ export default function SoundPlayer(props) {
           />
         </TouchableOpacity>
 
-        <TouchableOpacity onPress={StopAudio} style={[styles.circleButton]}>
+        <TouchableOpacity
+          onPress={StopAudio}
+          style = {
+            props.getShiftedURI() === "NOT SET"
+              ? [styles.circleButton, {backgroundColor: COLORS.GREY}]
+              : styles.circleButton
+            }
+        >
           <Image source={require("../../images/stop.png")} style={styles.icon} />
         </TouchableOpacity>
-        <TouchableOpacity onPress={ReplayAudio} style={styles.circleButton}>
+        <TouchableOpacity
+          onPress={ReplayAudio}
+          style = {
+            props.getShiftedURI() === "NOT SET"
+              ? [styles.circleButton, {backgroundColor: COLORS.GREY}]
+              : styles.circleButton
+            }
+        >
           <Image
             source={require("../../images/replay-music.png")}
             style={styles.icon}

--- a/Components/FrequencyAdjuster/AdjusterPlayer.js
+++ b/Components/FrequencyAdjuster/AdjusterPlayer.js
@@ -93,9 +93,10 @@ export default function SoundPlayer(props) {
         setURI(result.uri);
         setTime(sound, 0);
         setDuration(result);
-
+        
         // start playing audio
-        sound.current.playFromPositionAsync(currentPos);
+        // If playing from load, start from 0
+        sound.current.playFromPositionAsync(0);
         setStatus(true);
         const interval = setInterval(updatePos, 300);
         setIntervalId(interval);
@@ -115,13 +116,9 @@ export default function SoundPlayer(props) {
     try {
       const result = await sound.current.getStatusAsync();
       if (result.isLoaded && shiftedURI === currentURI) {
+        // FIXME: if you press play instead of replay when loading new audio
         if (result.isPlaying === false) {
-          if (currentPos === totalLength) {
-            sound.current.playFromPositionAsync(0);
-          }
-          else {
-            sound.current.playFromPositionAsync(currentPos);
-          }
+          sound.current.playFromPositionAsync(currentPos);
           setStatus(true);
           const interval = setInterval(updatePos, 300);
           setIntervalId(interval);
@@ -158,6 +155,10 @@ export default function SoundPlayer(props) {
 
   const StopAudio = async () => {
     try {
+      if (shiftedURI === "NOT SET"){
+        openModal();
+        return;
+      }
       sound.current.stopAsync();
       setStatus(false);
       setTime(sound, 0);

--- a/Components/FrequencyAdjuster/AdjusterPlayer.js
+++ b/Components/FrequencyAdjuster/AdjusterPlayer.js
@@ -73,11 +73,11 @@ export default function SoundPlayer(props) {
         setURI(result.uri);
         setTime(sound, 0);
         setDuration(result);
-        if (result.isLoaded === false) {
-          console.log("Error in Loadng Audio");
-        } else {
-          await PlayAudio();
-        }
+        // if (result.isLoaded === false) {
+        //   console.log("Error in Loadng Audio");
+        // } else {
+        //   await PlayAudio();
+        // }
       } catch (error) {
         console.log("Error in Loading Audio: " + error);
       }
@@ -87,6 +87,7 @@ export default function SoundPlayer(props) {
   const PlayAudio = async () => {
     try {
       const result = await sound.current.getStatusAsync();
+      // what to do if old is loaded?
       if (result.isLoaded && shiftedURI === currentURI) {
         if (result.isPlaying === false) {
           if (currentPos === totalLength) {

--- a/Components/FrequencyAdjuster/AdjusterPlayer.js
+++ b/Components/FrequencyAdjuster/AdjusterPlayer.js
@@ -57,12 +57,14 @@ export default function SoundPlayer(props) {
 
     if (shiftedURI === "NOT SET"){
       console.log("Attempting to load before audio is recorded!");
+      // TODO: could open modal here
+      return;
     }
     else if (shiftedURI === currentURI) {
       console.log("Already loaded");
+      return;
     }
-
-    else{
+    else {
       try {
         console.log("props.shiftedURI = " + shiftedURI);
         await sound.current.unloadAsync();
@@ -85,7 +87,7 @@ export default function SoundPlayer(props) {
   const PlayAudio = async () => {
     try {
       const result = await sound.current.getStatusAsync();
-      if (result.isLoaded) {
+      if (result.isLoaded && shiftedURI === currentURI) {
         if (result.isPlaying === false) {
           if (currentPos === totalLength) {
             sound.current.playFromPositionAsync(0);

--- a/Components/FrequencyAdjuster/FrequencyAdjuster.js
+++ b/Components/FrequencyAdjuster/FrequencyAdjuster.js
@@ -43,19 +43,21 @@ export default function FrequencyAdjuster() {
     setRecordModalVisible(true);
   };
 
-  state = {
-    shiftedURI: "NOT SET",
-  };
+  const [shiftedURI, setShiftedURI] = React.useState("NOT SET");
+  // state = {
+  //   shiftedURI: "NOT SET",
+  // };
 
   changeShiftedURI = (shiftedURI) => {
     console.log("parent input = " + shiftedURI);
-    this.state.URI = shiftedURI;
-    // this.setState({URI: shiftedURI});
-    console.log("parent state = " + this.state.URI);
+    // this.state.URI = shiftedURI;
+    setShiftedURI(shiftedURI);
+    // console.log("parent state = " + this.state.URI);
   };
 
   getShiftedURI = () => {
-    return this.state.URI;
+    // return this.state.URI;
+    return shiftedURI;
   };
 
   return (

--- a/Components/WelcomePage.js
+++ b/Components/WelcomePage.js
@@ -43,7 +43,7 @@ export default function FrequencyTester() {
           or you can upload or record audios to have their frequencies adjusted
           as well.{"\n"} {"\n"}
           If you ever need more instructions for a page, there will be a
-          question mark button in the top right corner of your screen you can
+          question mark button in the bottom right corner of your screen you can
           click for a tutorial.
         </Text>
       </View>


### PR DESCRIPTION
Eliminated an issue where LoadAudio would throw errors because it was already loading but the loading was failing due to other error -> could never load the audio. Now if you press the play/replay buttons while the audio is still loading nothing happens.

Updated slider to hopefully fix the incorrect timestamps issue; changes the final timestamp in the updatePos function using result instead of the state variable because the state variable doesn't update in the function. The interval does not clear but this isn't a priority atm